### PR TITLE
add config user

### DIFF
--- a/lua/plugins/user.lua
+++ b/lua/plugins/user.lua
@@ -42,7 +42,7 @@ return {
         ["<C-f>"] = cmp.mapping.scroll_docs(4),
         ["<C-Space>"] = cmp.mapping.complete(),
         ["<C-e>"] = cmp.mapping.abort(),
-        ["<CR>"] = cmp.mapping.confirm { select = true }, -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
+        ["<CR>"] = cmp.mapping.confirm { select = false }, -- Accept currently selected item. Set `select` to `false` to only confirm explicitly selected items.
         ["<Tab>"] = cmp.mapping(function(fallback)
           if cmp.visible() then
             cmp.select_next_item()


### PR DESCRIPTION
This pull request makes a small but important change to the `lua/plugins/user.lua` file, adjusting the behavior of the `<CR>` key when confirming autocomplete suggestions.

* [`lua/plugins/user.lua`](diffhunk://#diff-198b05cba517df75101c39ad19ff87fed6db322ea83a1af861c2ae7105b3ba4bL45-R45): Changed the `select` option in the `cmp.mapping.confirm` function from `true` to `false`, ensuring that pressing `<CR>` only confirms explicitly selected autocomplete items rather than automatically selecting the first item.