### PR TITLE
feat: enable copilot

### DIFF
--- a/lua/plugins/user.lua
+++ b/lua/plugins/user.lua
@@ -13,7 +13,10 @@ return {
     config = function()
       require("copilot").setup {
         suggestion = {
-          auto_trigger = false,
+          auto_trigger = true,
+          keymap = {
+            accept = "<Right>",
+          },
         },
       }
     end,


### PR DESCRIPTION
This pull request makes a small configuration change to the `lua/plugins/user.lua` file to improve the behavior of the Copilot plugin. The change enables automatic suggestion triggering and adds a key mapping for accepting suggestions.

* [`lua/plugins/user.lua`](diffhunk://#diff-198b05cba517df75101c39ad19ff87fed6db322ea83a1af861c2ae7105b3ba4bL16-R19): Changed `auto_trigger` to `true` to enable automatic suggestion triggering and added a keymap binding for accepting suggestions using the `<Right>` key.add right key to completion